### PR TITLE
Add Docker context picker and default context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Use `:ctx` to open the Docker context picker, switch the current d4s session to 
 
 If `DOCKER_HOST` or `DOCKER_CONTEXT` is set in your shell, those environment variables still override the saved D4S default for that launch.
 
+In a container log view opened with `l`, use `:logdump` or `:ld` to export the full log of that container to `~/.config/d4s/logs/<container-id>.<timestamp>.log` (or the equivalent `$XDG_CONFIG_HOME/d4s/logs/...` path).
+
 ## Contributing
 
 There's still plenty to do! Take a look at the [contributing guide](CONTRIBUTING.md) to see how you can help.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ d4s --context my-remote-ctx
 
 D4S uses a YAML configuration file located at `$XDG_CONFIG_HOME/d4s/config.yaml` (defaults to `~/.config/d4s/config.yaml`).
 
+### Context Selection Precedence
+
+When deciding which Docker context to use, D4S applies the following precedence:
+
+1. `--context` / `-c`
+2. `DOCKER_HOST`
+3. `DOCKER_CONTEXT`
+4. `d4s.defaultContext` from `config.yaml`
+5. Docker CLI's own current/default context behavior
+
+If you select the literal `default` context from `:ctx`, D4S uses Docker's normal default context resolution rather than a named custom context.
+
 All settings are optional and have sensible defaults. Below is a fully documented example:
 
 ```yaml
@@ -178,6 +190,8 @@ d4s:
   apiServerTimeout: 15s
   # Disable all modification commands (delete, kill, restart, etc.). Default: false
   readOnly: false
+  # Default Docker context for d4s when --context, DOCKER_HOST, and DOCKER_CONTEXT are not set. Default: ""
+  defaultContext: ""
   # Default view on startup (containers, images, volumes, networks, services, nodes, compose, secrets). Default: "" (containers)
   defaultView: ""
   # When true, Ctrl+C won't exit — use :quit instead. Default: false
@@ -218,6 +232,14 @@ d4s:
     image: ghcr.io/jr-k/nget:latest
 ```
 
+Example: pin D4S to a preferred remote context by default:
+
+```yaml
+d4s:
+  defaultContext: "my-remote-ctx"
+  defaultView: "containers"
+```
+
 ## Skins
 
 ### Built-in Skins
@@ -237,6 +259,12 @@ D4S comes with a few built-in skins:
 
 D4S supports custom skins. Skins are stored in `$XDG_DATA_HOME/d4s/skins/<name>.yaml` (defaults to `~/.local/share/d4s/skins`).
 
+## Command Palette
+
+Use `:ctx` to open the Docker context picker, switch the current d4s session to a different context, and save that selection as the default context for future d4s launches.
+
+If `DOCKER_HOST` or `DOCKER_CONTEXT` is set in your shell, those environment variables still override the saved D4S default for that launch.
+
 ## Contributing
 
 There's still plenty to do! Take a look at the [contributing guide](CONTRIBUTING.md) to see how you can help.
@@ -250,4 +278,3 @@ There's still plenty to do! Take a look at the [contributing guide](CONTRIBUTING
 *Built with Go & Tview. Inspired by K9s.*
 
 *D4s uses several open source libraries. Thanks to the maintainers who make this possible.*
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,20 @@ func configDir() string {
 	return filepath.Join(home, ".config", "d4s")
 }
 
+// ConfigDir returns the d4s config directory, respecting XDG_CONFIG_HOME.
+func ConfigDir() string {
+	return configDir()
+}
+
+// LogsDir returns the directory used for d4s log exports.
+func LogsDir() string {
+	dir := configDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "logs")
+}
+
 // ensureConfigDirs creates the config directory and skins subdirectory if they don't exist.
 func ensureConfigDirs() {
 	dir := configDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,11 +15,12 @@ type Config struct {
 }
 
 type D4SConfig struct {
-	RefreshRate         float64 `yaml:"refreshRate"`
-	APIServerTimeout    string `yaml:"apiServerTimeout"`
-	ReadOnly            bool   `yaml:"readOnly"`
-	DefaultView         string `yaml:"defaultView"`
-	NoExitOnCtrlC       bool   `yaml:"noExitOnCtrlC"`
+	RefreshRate      float64 `yaml:"refreshRate"`
+	APIServerTimeout string  `yaml:"apiServerTimeout"`
+	ReadOnly         bool    `yaml:"readOnly"`
+	DefaultContext   string  `yaml:"defaultContext"`
+	DefaultView      string  `yaml:"defaultView"`
+	NoExitOnCtrlC    bool    `yaml:"noExitOnCtrlC"`
 
 	UI UIConfig `yaml:"ui"`
 
@@ -112,6 +114,7 @@ func DefaultConfig() *Config {
 			RefreshRate:      2.0,
 			APIServerTimeout: "120s",
 			ReadOnly:         false,
+			DefaultContext:   "",
 			DefaultView:      "",
 			NoExitOnCtrlC:    false,
 			UI: UIConfig{
@@ -193,4 +196,26 @@ func Load() *Config {
 	}
 
 	return parsed
+}
+
+// Save writes the config back to $XDG_CONFIG_HOME/d4s/config.yaml.
+func Save(cfg *Config) error {
+	if cfg == nil {
+		return errors.New("nil config")
+	}
+
+	dir := configDir()
+	if dir == "" {
+		return errors.New("unable to determine config directory")
+	}
+
+	ensureConfigDirs()
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(dir, "config.yaml")
+	return os.WriteFile(configPath, data, 0o644)
 }

--- a/internal/dao/context.go
+++ b/internal/dao/context.go
@@ -1,0 +1,85 @@
+package dao
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	dockerconfig "github.com/docker/cli/cli/config"
+	dockercontext "github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/store"
+	dockerclient "github.com/docker/docker/client"
+)
+
+type ContextInfo struct {
+	Name           string
+	Description    string
+	DockerEndpoint string
+}
+
+type dockerContextMeta struct {
+	Description string `json:"Description,omitempty"`
+}
+
+func newContextStore() *store.ContextStore {
+	return store.New(dockerconfig.ContextStoreDir(), store.NewConfig(
+		func() interface{} {
+			return &dockerContextMeta{}
+		},
+		store.EndpointTypeGetter(dockercontext.DockerEndpoint, func() interface{} { return &dockercontext.EndpointMeta{} }),
+	))
+}
+
+func ListContexts() ([]ContextInfo, error) {
+	contexts, err := newContextStore().List()
+	if err != nil {
+		return nil, err
+	}
+	contexts = append(contexts, defaultContextMetadata())
+
+	items := make([]ContextInfo, 0, len(contexts))
+	for _, raw := range contexts {
+		meta := dockerContextMeta{}
+		if typed, ok := raw.Metadata.(dockerContextMeta); ok {
+			meta = typed
+		}
+
+		host := ""
+		if endpoint, err := dockercontext.EndpointFromContext(raw); err == nil {
+			host = endpoint.Host
+		}
+
+		items = append(items, ContextInfo{
+			Name:           raw.Name,
+			Description:    strings.TrimSpace(meta.Description),
+			DockerEndpoint: strings.TrimSpace(host),
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+	})
+
+	return items, nil
+}
+
+func (d *DockerClient) ListContexts() ([]ContextInfo, error) {
+	return ListContexts()
+}
+
+func defaultContextMetadata() store.Metadata {
+	host := os.Getenv("DOCKER_HOST")
+	if host == "" {
+		host = dockerclient.DefaultDockerHost
+	}
+
+	return store.Metadata{
+		Name: "default",
+		Metadata: dockerContextMeta{
+			Description: "Current DOCKER_HOST based configuration",
+		},
+		Endpoints: map[string]any{
+			dockercontext.DockerEndpoint: dockercontext.EndpointMeta{Host: host},
+		},
+	}
+}

--- a/internal/dao/docker.go
+++ b/internal/dao/docker.go
@@ -14,10 +14,9 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/config"
-	clicontext "github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/connhelper"
+	clicontext "github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/docker"
-	"github.com/docker/cli/cli/context/store"
 	dcontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -58,10 +57,10 @@ type mountInfoCache struct {
 }
 
 type DockerClient struct {
-	Cli *client.Client
-	Ctx context.Context
+	Cli         *client.Client
+	Ctx         context.Context
 	ContextName string
-	
+
 	// Managers
 	Container *container.Manager
 	Image     *image.Manager
@@ -73,22 +72,22 @@ type DockerClient struct {
 	Compose   *compose.Manager
 
 	// Resource cache for fast scoped queries and stale-while-revalidate
-	cacheMu              sync.RWMutex
-	volumeCache          []common.Resource            // Raw Volume.List() results (for scoped queries)
-	enrichedVolumeCache  []common.Resource            // Full ListVolumes() result (with UsedBy)
-	networkCache         []common.Resource            // Network.List() results
-	containerInfoMap     map[string]containerInfoCache // containerID -> mount/network info
+	cacheMu             sync.RWMutex
+	volumeCache         []common.Resource             // Raw Volume.List() results (for scoped queries)
+	enrichedVolumeCache []common.Resource             // Full ListVolumes() result (with UsedBy)
+	networkCache        []common.Resource             // Network.List() results
+	containerInfoMap    map[string]containerInfoCache // containerID -> mount/network info
 
 	// Guard against concurrent async refreshes
 	refreshMu  sync.Mutex
 	refreshing map[string]bool
 }
 
-func NewDockerClient(contextName string, apiTimeout time.Duration) (*DockerClient, error) {
+func NewDockerClient(contextName string, apiTimeout time.Duration, defaultContext string) (*DockerClient, error) {
 	logger, cleanup := initLogger()
 	defer cleanup()
 
-	ctxName, opts, err := resolveClientOpts(contextName, logger, apiTimeout)
+	ctxName, opts, err := resolveClientOpts(contextName, defaultContext, logger, apiTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +97,7 @@ func NewDockerClient(contextName string, apiTimeout time.Duration) (*DockerClien
 		return nil, err
 	}
 	ctx := context.Background()
-	
+
 	return &DockerClient{
 		Cli:              cli,
 		Ctx:              ctx,
@@ -124,13 +123,20 @@ func initLogger() (*log.Logger, func()) {
 	return log.New(f, "d4s-dao: ", log.LstdFlags), func() { f.Close() }
 }
 
-func resolveClientOpts(flagContext string, logger *log.Logger, apiTimeout time.Duration) (string, []client.Opt, error) {
+func resolveClientOpts(flagContext string, defaultContext string, logger *log.Logger, apiTimeout time.Duration) (string, []client.Opt, error) {
 	opts := []client.Opt{
 		client.WithAPIVersionNegotiation(),
 	}
+	flagContext = strings.TrimSpace(flagContext)
+	defaultContext = strings.TrimSpace(defaultContext)
 
 	// 1. Flag takes precedence
 	if flagContext != "" {
+		if flagContext == "default" {
+			logger.Println("Explicit default context requested via flag, using FromEnv")
+			opts = append(opts, client.FromEnv)
+			return "default", opts, nil
+		}
 		logger.Printf("Explicit context requested via flag: %s", flagContext)
 		opts, err := loadSpecificContext(flagContext, logger, opts, apiTimeout)
 		return flagContext, opts, err
@@ -143,18 +149,39 @@ func resolveClientOpts(flagContext string, logger *log.Logger, apiTimeout time.D
 		return "env", opts, nil
 	}
 
-	// 3. Identify Target Context
-	targetCtx := "default"
-	if envCtx := os.Getenv("DOCKER_CONTEXT"); envCtx != "" {
-		targetCtx = envCtx
-		logger.Printf("DOCKER_CONTEXT set to %s", targetCtx)
-	} else {
-		if cfg, err := config.Load(config.Dir()); err == nil && cfg.CurrentContext != "" {
-			targetCtx = cfg.CurrentContext
-			logger.Printf("Loaded CurrentContext from config: %s", targetCtx)
-		} else if err != nil {
-			logger.Printf("Failed to load config: %v", err)
+	// 3. DOCKER_CONTEXT takes precedence over d4s config
+	if envCtx := strings.TrimSpace(os.Getenv("DOCKER_CONTEXT")); envCtx != "" {
+		logger.Printf("DOCKER_CONTEXT set to %s", envCtx)
+		if envCtx == "default" {
+			opts = append(opts, client.FromEnv)
+			return "default", opts, nil
 		}
+		opts, err := loadSpecificContext(envCtx, logger, opts, apiTimeout)
+		return envCtx, opts, err
+	}
+
+	// 4. d4s config default context, if provided
+	if defaultContext != "" {
+		if defaultContext == "default" {
+			logger.Println("Using d4s default context: default")
+			opts = append(opts, client.FromEnv)
+			return "default", opts, nil
+		}
+		logger.Printf("Using d4s default context: %s", defaultContext)
+		opts, err := loadSpecificContext(defaultContext, logger, opts, apiTimeout)
+		if err == nil {
+			return defaultContext, opts, nil
+		}
+		logger.Printf("Failed to load d4s default context %s: %v", defaultContext, err)
+	}
+
+	// 5. Identify Target Context
+	targetCtx := "default"
+	if cfg, err := config.Load(config.Dir()); err == nil && cfg.CurrentContext != "" {
+		targetCtx = cfg.CurrentContext
+		logger.Printf("Loaded CurrentContext from config: %s", targetCtx)
+	} else if err != nil {
+		logger.Printf("Failed to load config: %v", err)
 	}
 
 	if targetCtx == "default" {
@@ -163,21 +190,15 @@ func resolveClientOpts(flagContext string, logger *log.Logger, apiTimeout time.D
 		return "default", opts, nil
 	}
 
-	// 4. Load Specific Context
+	// 6. Load Specific Context
 	opts, err := loadSpecificContext(targetCtx, logger, opts, apiTimeout)
 	return targetCtx, opts, err
 }
 
 func loadSpecificContext(targetCtx string, logger *log.Logger, baseOpts []client.Opt, apiTimeout time.Duration) ([]client.Opt, error) {
 	logger.Printf("Loading context: %s", targetCtx)
-	
-	// Create store with docker endpoint registered
-	s := store.New(config.ContextStoreDir(), store.NewConfig(
-		func() interface{} {
-			return &map[string]interface{}{}
-		},
-		store.EndpointTypeGetter(docker.DockerEndpoint, func() interface{} { return &docker.EndpointMeta{} }),
-	))
+
+	s := newContextStore()
 
 	meta, err := s.GetMetadata(targetCtx)
 	if err != nil {
@@ -594,7 +615,6 @@ func (d *DockerClient) GetServiceNetworks(id string) ([]swarm.NetworkAttachmentC
 func (d *DockerClient) SetServiceNetworks(id string, networks []swarm.NetworkAttachmentConfig) error {
 	return d.Service.SetNetworks(id, networks)
 }
-
 
 func (d *DockerClient) ListServicesForSecret(secretID string) ([]common.Resource, error) {
 	services, err := d.Service.List()

--- a/internal/dao/docker/container/container.go
+++ b/internal/dao/docker/container/container.go
@@ -28,7 +28,7 @@ type CachedStats struct {
 type Manager struct {
 	cli *client.Client
 	ctx context.Context
-	
+
 	statsCache map[string]CachedStats
 	statsMutex sync.RWMutex
 	updating   int32
@@ -36,8 +36,8 @@ type Manager struct {
 
 func NewManager(cli *client.Client, ctx context.Context) *Manager {
 	return &Manager{
-		cli: cli, 
-		ctx: ctx,
+		cli:        cli,
+		ctx:        ctx,
 		statsCache: make(map[string]CachedStats),
 	}
 }
@@ -146,11 +146,11 @@ func (m *Manager) updateStats(containers []types.Container) {
 	if !atomic.CompareAndSwapInt32(&m.updating, 0, 1) {
 		return
 	}
-	
+
 	// Create a detached operation, do not block caller
 	go func() {
 		defer atomic.StoreInt32(&m.updating, 0)
-		
+
 		var wg sync.WaitGroup
 		sem := make(chan struct{}, 5) // Limit concurrency
 
@@ -169,9 +169,9 @@ func (m *Manager) updateStats(containers []types.Container) {
 				if err != nil {
 					return
 				}
-				
+
 				cpuPct, mem, _ := common.CalculateContainerStats(statsResp.Body)
-				
+
 				colorTag := ""
 				if cpuPct >= 90.0 {
 					colorTag = fmt.Sprintf("[%s::b]", styles.TagError)
@@ -211,7 +211,7 @@ func (m *Manager) List() ([]common.Resource, error) {
 		if len(c.Names) > 0 {
 			name = strings.TrimPrefix(c.Names[0], "/")
 		}
-		
+
 		seen := make(map[string]bool)
 		portList := make([]string, 0, len(c.Ports))
 		for _, p := range c.Ports {
@@ -230,7 +230,7 @@ func (m *Manager) List() ([]common.Resource, error) {
 		} else if proj, ok := c.Labels["com.docker.compose.project"]; ok {
 			compose = "📦 " + proj
 		}
-		
+
 		projectName := c.Labels["com.docker.compose.project"]
 		serviceName := c.Labels["com.docker.swarm.service.name"]
 
@@ -239,7 +239,7 @@ func (m *Manager) List() ([]common.Resource, error) {
 		// Fetch Stats from Cache
 		cpuStr := "-"
 		memStr := "-"
-		
+
 		if c.State != "running" {
 			cpuStr = "-"
 			memStr = "-"
@@ -343,6 +343,16 @@ func (m *Manager) Logs(id string, since string, tail string, timestamps bool) (i
 		opts.Tail = "all"
 	}
 	return m.cli.ContainerLogs(m.ctx, id, opts)
+}
+
+func (m *Manager) LogsSnapshot(id string, timestamps bool) (io.ReadCloser, error) {
+	return m.cli.ContainerLogs(m.ctx, id, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     false,
+		Tail:       "all",
+		Timestamps: timestamps,
+	})
 }
 
 func (m *Manager) GetEnv(id string) ([]string, error) {

--- a/internal/dao/logdump.go
+++ b/internal/dao/logdump.go
@@ -1,0 +1,28 @@
+package dao
+
+import (
+	"io"
+
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+func (d *DockerClient) DumpContainerLogs(id string, w io.Writer, timestamps bool) error {
+	reader, err := d.Container.LogsSnapshot(id, timestamps)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	hasTTY, err := d.HasTTY(id)
+	if err != nil {
+		return err
+	}
+
+	if hasTTY {
+		_, err = io.Copy(w, reader)
+		return err
+	}
+
+	_, err = stdcopy.StdCopy(w, w, reader)
+	return err
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -44,7 +44,7 @@ type App struct {
 	Pages   *tview.Pages
 	CmdLine *command.CommandComponent
 	Flash   *footer.FlashComponent
-	Help tview.Primitive
+	Help    tview.Primitive
 
 	// Views
 	Views map[string]*view.ResourceView
@@ -56,16 +56,16 @@ type App struct {
 	ActiveInspector common.Inspector
 	PreviousView    string
 	CurrentView     string // Track current view name before inspector
-	LatestVersion   string 
+	LatestVersion   string
 
 	// Concurrency
 	pauseMx    sync.RWMutex
 	paused     bool
 	stopTicker chan struct{}
-	
-	flashMx    sync.Mutex
+
+	flashMx     sync.Mutex
 	flashExpiry time.Time
-	
+
 	appendTimer *time.Timer
 	appendMx    sync.Mutex
 }
@@ -105,7 +105,7 @@ func NewApp(contextName string, cfg *config.Config) (*App, error) {
 		styles.InvertColors()
 	}
 
-	docker, err := dao.NewDockerClient(contextName, cfg.D4S.GetAPIServerTimeout())
+	docker, err := dao.NewDockerClient(contextName, cfg.D4S.GetAPIServerTimeout(), cfg.D4S.DefaultContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init docker client: %w", err)
 	}
@@ -114,7 +114,7 @@ func NewApp(contextName string, cfg *config.Config) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create screen: %w", err)
 	}
-	
+
 	tviewApp := tview.NewApplication()
 	tviewApp.SetScreen(screen)
 
@@ -146,7 +146,7 @@ func (a *App) Run() error {
 
 	// Start auto-refresh
 	a.StartAutoRefresh()
-	
+
 	// Check for updates (unless skipped by config)
 	if !a.Cfg.D4S.SkipLatestRevCheck {
 		go a.checkLatestVersion()
@@ -180,12 +180,12 @@ func (a *App) StartAutoRefresh() {
 		// We use a small delay on first run to let UI settle if needed, but only for the first ever run
 		// subsequent restarts of auto-refresh might want immediate effect or wait for next tick.
 		// Let's rely on tick.
-		
+
 		ticker := time.NewTicker(a.Cfg.D4S.GetRefreshInterval())
 		defer ticker.Stop()
 
 		// Immediate update on start
-		// a.RefreshCurrentView() calls a.UpdateShortcuts() which calls tview methods. 
+		// a.RefreshCurrentView() calls a.UpdateShortcuts() which calls tview methods.
 		// Since we are in a goroutine here, we MUST queue.
 		a.SafeQueueUpdateDraw(func() {
 			// Actually RefreshCurrentView spawns BG task, so we shouldn't wrap the whole thing?
@@ -245,9 +245,9 @@ func (a *App) initUI() {
 	vImages.RemoveFunc = images.Remove
 	vImages.PruneFunc = images.Prune
 	vImages.Headers = images.Headers
-	
+
 	// Default Sort: Containers (Index 3) DESC
-	vImages.SortCol = 3 
+	vImages.SortCol = 3
 	vImages.SortAsc = false
 
 	vImages.InputHandler = func(event *tcell.EventKey) *tcell.EventKey {
@@ -361,7 +361,7 @@ func (a *App) initUI() {
 		a.Layout.AddItem(a.Header.View, 7, 1, false)
 	}
 	a.Layout.AddItem(a.CmdLine.View, 0, 0, false). // Hidden by default (size 0, proportion 0)
-		AddItem(a.Pages, 0, 1, true)
+							AddItem(a.Pages, 0, 1, true)
 
 	if !a.Cfg.D4S.UI.Crumbsless {
 		a.Layout.AddItem(a.Flash.View, 2, 1, false)
@@ -369,7 +369,7 @@ func (a *App) initUI() {
 
 	// Global Shortcuts
 	a.TviewApp.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		
+
 		// Priority 0: Global Exit on Ctrl+C (unless noExitOnCtrlC is set)
 		if event.Key() == tcell.KeyCtrlC {
 			if !a.Cfg.D4S.NoExitOnCtrlC {
@@ -411,9 +411,9 @@ func (a *App) initUI() {
 			if scope != nil {
 				origin := scope.OriginView
 				parent := scope.Parent
-				
+
 				a.SafeSetScope(parent) // Pop breadcrumb
-				
+
 				// Navigate back: either to parent's active view (if we can infer it?)
 				// Or use OriginView. OriginView is the view we were in when we drilled down.
 				// This matches "Back" behavior perfectly.
@@ -448,7 +448,7 @@ func (a *App) initUI() {
 			} else {
 				// Go to aliases
 				// We use SwitchToWithSelection to populate PreviousView and handle focus
-				a.SwitchToWithSelection(styles.TitleAliases, false) 
+				a.SwitchToWithSelection(styles.TitleAliases, false)
 			}
 			return nil
 		}
@@ -552,7 +552,7 @@ func (a *App) SetActiveScope(scope *common.Scope) {
 	// If different from current, stack it
 	if a.ActiveScope != nil {
 		// Only stack if it's a new drill-down (different value or type)
-		// Prevent stacking identical scopes if called repeatedly? 
+		// Prevent stacking identical scopes if called repeatedly?
 		// Actually typical usage is creating a NEW struct instance, so we check content.
 		if a.ActiveScope.Value != scope.Value || a.ActiveScope.Type != scope.Type {
 			scope.Parent = a.ActiveScope
@@ -646,7 +646,7 @@ func (a *App) OpenInspector(inspector common.Inspector) {
 	a.Pages.AddPage("inspect", inspector.GetPrimitive(), true, true)
 	a.TviewApp.SetFocus(inspector.GetPrimitive())
 	a.UpdateShortcuts()
-	
+
 	// Force immediate update of breadcrumb/UI
 	a.RefreshCurrentView()
 }
@@ -663,7 +663,7 @@ func (a *App) CloseInspector() {
 
 	a.RestoreFocus()
 	a.UpdateShortcuts()
-	
+
 	// Force immediate update of breadcrumb/UI
 	a.RefreshCurrentView()
 }
@@ -688,7 +688,6 @@ func (a *App) IsPaused() bool {
 	defer a.pauseMx.RUnlock()
 	return a.paused
 }
-
 
 func (a *App) SetFlashText(text string) {
 	a.flashMx.Lock()
@@ -717,7 +716,7 @@ func (a *App) AppendFlash(text string) {
 	})
 }
 
-func  (a *App) AppendFlashError(text string) {
+func (a *App) AppendFlashError(text string) {
 	a.AppendFlash(fmt.Sprintf("[black:red] <error: %s> [-:-]", text))
 }
 
@@ -733,7 +732,7 @@ func (a *App) SetFlashMessage(text string, duration time.Duration) {
 	a.flashMx.Lock()
 	a.flashExpiry = time.Now().Add(duration)
 	a.flashMx.Unlock()
-	
+
 	a.Flash.SetText(text)
 }
 
@@ -764,7 +763,7 @@ func (a *App) SafeQueueUpdateDraw(f func()) {
 		return
 	}
 
-	// ALWAYS run QueueUpdateDraw in a goroutine to avoid deadlocks if called from within a callback 
+	// ALWAYS run QueueUpdateDraw in a goroutine to avoid deadlocks if called from within a callback
 	// that holds internal tview locks (though QueueUpdateDraw is supposed to be safe, sometimes it blocks).
 	// Actually, QueueUpdateDraw puts it in a channel.
 	go a.TviewApp.QueueUpdateDraw(func() {

--- a/internal/ui/app_context.go
+++ b/internal/ui/app_context.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/jr-k/d4s/internal/config"
+	"github.com/jr-k/d4s/internal/dao"
+	"github.com/jr-k/d4s/internal/ui/dialogs"
+)
+
+func (a *App) ShowContextPicker() {
+	contexts, err := a.Docker.ListContexts()
+	if err != nil {
+		a.AppendFlashError(fmt.Sprintf("failed to load docker contexts: %v", err))
+		return
+	}
+
+	active := strings.TrimSpace(a.Docker.ContextName)
+	saved := strings.TrimSpace(a.Cfg.D4S.DefaultContext)
+
+	items := make([]dialogs.PickerItem, 0, len(contexts))
+	for _, ctx := range contexts {
+		var markers []string
+		if ctx.Name == active {
+			markers = append(markers, "active")
+		}
+		if ctx.Name == saved {
+			markers = append(markers, "default")
+		}
+
+		var details []string
+		if len(markers) > 0 {
+			details = append(details, strings.Join(markers, ", "))
+		}
+		if ctx.DockerEndpoint != "" {
+			details = append(details, shortenContextText(ctx.DockerEndpoint, 30))
+		} else if ctx.Description != "" {
+			details = append(details, shortenContextText(ctx.Description, 30))
+		}
+
+		description := "Select as d4s default context"
+		if len(details) > 0 {
+			description = strings.Join(details, " • ")
+		}
+
+		items = append(items, dialogs.PickerItem{
+			Label:       ctx.Name,
+			Description: description,
+			Value:       ctx.Name,
+		})
+	}
+
+	dialogs.ShowPicker(a, "Docker Contexts", items, func(value string) {
+		a.SetDefaultContext(value)
+	})
+}
+
+func (a *App) SetDefaultContext(contextName string) {
+	contextName = strings.TrimSpace(contextName)
+	if contextName == "" {
+		a.AppendFlashError("context name cannot be empty")
+		return
+	}
+
+	if a.Docker != nil && a.Docker.ContextName == contextName {
+		a.Cfg.D4S.DefaultContext = contextName
+		if err := config.Save(a.Cfg); err != nil {
+			a.AppendFlashError(fmt.Sprintf("failed to save default context: %v", err))
+			return
+		}
+
+		a.AppendFlashSuccess(contextSavedMessage(contextName))
+		a.updateHeader()
+		return
+	}
+
+	a.SetFlashPending(fmt.Sprintf("switching context to %s...", contextName))
+	a.SetPaused(true)
+	a.StopAutoRefresh()
+
+	if a.ActiveInspector != nil {
+		a.ActiveInspector.OnUnmount()
+		a.ActiveInspector = nil
+	}
+	if a.Pages.HasPage("inspect") {
+		a.Pages.RemovePage("inspect")
+	}
+
+	a.SafeSetScope(nil)
+	a.ActiveFilter = ""
+	for _, v := range a.Views {
+		v.SetLoading(true)
+	}
+	a.RestoreFocus()
+	a.UpdateShortcuts()
+
+	a.RunInBackground(func() {
+		newDocker, err := dao.NewDockerClient(contextName, a.Cfg.D4S.GetAPIServerTimeout(), contextName)
+		if err != nil {
+			a.TviewApp.QueueUpdateDraw(func() {
+				a.SetPaused(false)
+				a.StartAutoRefresh()
+				a.AppendFlashError(fmt.Sprintf("failed to switch context: %v", err))
+				a.RefreshCurrentView()
+				a.updateHeader()
+			})
+			return
+		}
+
+		a.Cfg.D4S.DefaultContext = contextName
+		saveErr := config.Save(a.Cfg)
+
+		a.TviewApp.QueueUpdateDraw(func() {
+			a.Docker = newDocker
+			a.SetPaused(false)
+			a.StartAutoRefresh()
+			a.RestoreFocus()
+			a.UpdateShortcuts()
+			a.updateHeader()
+			a.RefreshCurrentView()
+			a.preloadViews()
+
+			if saveErr != nil {
+				a.AppendFlashError(fmt.Sprintf("switched to %s, but failed to save default: %v", contextName, saveErr))
+				return
+			}
+
+			a.AppendFlashSuccess(contextSavedMessage(contextName))
+		})
+	})
+}
+
+func contextSavedMessage(name string) string {
+	msg := fmt.Sprintf("default context set to %s", name)
+	if os.Getenv("DOCKER_HOST") != "" || os.Getenv("DOCKER_CONTEXT") != "" {
+		msg += " (env vars still override on startup)"
+	}
+	return msg
+}
+
+func shortenContextText(text string, max int) string {
+	if max <= 3 || len(text) <= max {
+		return text
+	}
+
+	keep := (max - 3) / 2
+	tail := max - 3 - keep
+	return text[:keep] + "..." + text[len(text)-tail:]
+}

--- a/internal/ui/app_logdump.go
+++ b/internal/ui/app_logdump.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/jr-k/d4s/internal/config"
+	daocommon "github.com/jr-k/d4s/internal/dao/common"
+	"github.com/jr-k/d4s/internal/ui/components/inspect"
+)
+
+func (a *App) DumpActiveContainerLogs() {
+	logInspector, ok := a.ActiveInspector.(*inspect.LogInspector)
+	if !ok || logInspector == nil {
+		a.AppendFlashError("logdump is only available in a container log view")
+		return
+	}
+	if logInspector.ResourceType != "container" {
+		a.AppendFlashError("logdump is only available in a container log view")
+		return
+	}
+
+	id := logInspector.ResourceID
+	fileID := id
+	if len(fileID) > 12 {
+		fileID = fileID[:12]
+	}
+	filePrefix := fileID
+	if subject := strings.TrimSpace(logInspector.Subject); subject != "" {
+		filePrefix = sanitizeLogFilenameSubject(subject, fileID)
+	}
+
+	logsDir := config.LogsDir()
+	if logsDir == "" {
+		a.AppendFlashError("unable to determine d4s logs directory")
+		return
+	}
+
+	a.SetFlashPending(fmt.Sprintf("dumping logs for %s...", id))
+
+	a.RunInBackground(func() {
+		if err := os.MkdirAll(logsDir, 0o755); err != nil {
+			a.SafeQueueUpdateDraw(func() {
+				a.AppendFlashError(fmt.Sprintf("failed to create logs dir: %v", err))
+			})
+			return
+		}
+
+		ts := time.Now().Format("20060102-150405")
+		path := filepath.Join(logsDir, fmt.Sprintf("%s.%s.log", filePrefix, ts))
+
+		f, err := os.Create(path)
+		if err != nil {
+			a.SafeQueueUpdateDraw(func() {
+				a.AppendFlashError(fmt.Sprintf("failed to create log file: %v", err))
+			})
+			return
+		}
+
+		dumpErr := a.Docker.DumpContainerLogs(id, f, true)
+		closeErr := f.Close()
+		if dumpErr == nil {
+			dumpErr = closeErr
+		}
+
+		a.SafeQueueUpdateDraw(func() {
+			if dumpErr != nil {
+				a.AppendFlashError(fmt.Sprintf("failed to dump logs: %v", dumpErr))
+				return
+			}
+			a.AppendFlashSuccess(fmt.Sprintf("logs dumped to %s", daocommon.ShortenPath(path)))
+		})
+	})
+}
+
+func sanitizeLogFilenameSubject(subject string, fallbackID string) string {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return fallbackID
+	}
+
+	subject = strings.ReplaceAll(subject, "@", ".")
+
+	var b strings.Builder
+	lastDot := false
+	for _, r := range subject {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+			lastDot = r == '.'
+		case !lastDot:
+			b.WriteByte('.')
+			lastDot = true
+		}
+	}
+
+	name := strings.Trim(b.String(), ".")
+	if name == "" {
+		return fallbackID
+	}
+	return name
+}

--- a/internal/ui/app_navigation.go
+++ b/internal/ui/app_navigation.go
@@ -45,6 +45,8 @@ func (a *App) ExecuteCmd(cmd string) {
 		a.SafeQueueUpdateDraw(func() {
 			a.ShowContextPicker()
 		})
+	case "ld", "logdump":
+		a.DumpActiveContainerLogs()
 	case "h", "help", "?":
 		a.Pages.AddPage("help", a.Help, true, true)
 	default:

--- a/internal/ui/app_navigation.go
+++ b/internal/ui/app_navigation.go
@@ -41,6 +41,10 @@ func (a *App) ExecuteCmd(cmd string) {
 		switchToRoot(styles.TitleAliases)
 	case "x", "sec", "secret", "secrets":
 		switchToRoot(styles.TitleSecrets)
+	case "ctx", "context", "contexts":
+		a.SafeQueueUpdateDraw(func() {
+			a.ShowContextPicker()
+		})
 	case "h", "help", "?":
 		a.Pages.AddPage("help", a.Help, true, true)
 	default:
@@ -60,20 +64,20 @@ func (a *App) SwitchToWithSelection(viewName string, reset bool) {
 	if v, ok := a.Views[viewName]; ok {
 		// Record previous view
 		current, _ := a.Pages.GetFrontPage()
-		
+
 		// Avoid stacking the same view as previous repeatedly
 		if current != "" && current != viewName && current != "inspect" {
 			// Only stack if it's a drill-down (new scope) or a distinct view switch
-			
+
 			// Simple deduplication for PreviousView
 			if a.PreviousView != current {
 				a.PreviousView = current
 			}
 		}
-		
+
 		// Always update CurrentView
 		a.CurrentView = viewName
-		
+
 		// Flush/Clear manual selection on view switch
 		v.SelectedIDs = make(map[string]bool)
 
@@ -84,7 +88,7 @@ func (a *App) SwitchToWithSelection(viewName string, reset bool) {
 		}
 
 		a.Pages.SwitchToPage(viewName)
-		
+
 		if reset {
 			a.ActiveFilter = ""
 			// Clear the view's filter as well since we are resetting
@@ -113,7 +117,7 @@ func (a *App) SwitchToWithSelection(viewName string, reset bool) {
 		}
 		// Same scope with existing data: keep it visible (preload benefit)
 
-		// Don't spawn a goroutine here! 
+		// Don't spawn a goroutine here!
 		// RefreshCurrentView accesses UI state (ActiveScope, FrontPage) and calls UpdateShortcuts (UI).
 		// It internally spawns a background task for the heavy lifting.
 		// Running it in 'go' causes race conditions with UI drawing.

--- a/internal/ui/components/command/command.go
+++ b/internal/ui/components/command/command.go
@@ -117,6 +117,8 @@ var availableCommands = []string{
 	"context",
 	"contexts",
 	"ctx",
+	"logdump",
+	"ld",
 	"help",
 	"aliases",
 	"q",
@@ -129,6 +131,7 @@ var availableCommands = []string{
 	"p",
 	"a",
 	"ctx",
+	"ld",
 }
 
 // findBestSuggestion finds the best matching command for autocompletion

--- a/internal/ui/components/command/command.go
+++ b/internal/ui/components/command/command.go
@@ -46,28 +46,28 @@ func (a *AutocompleteInputField) SetApplication(app *tview.Application) {
 func (a *AutocompleteInputField) Draw(screen tcell.Screen) {
 	// Draw the base InputField first
 	a.InputField.Draw(screen)
-	
+
 	// Then draw the suggestion in gray if it exists and we have focus
 	if a.suggestionText != "" && a.HasFocus() {
 		x, y, width, _ := a.GetInnerRect()
 		text := a.GetText()
 		label := a.GetLabel()
-		
+
 		// Calculate the position where the suggestion should appear
 		// We use simple length calculation for stability
 		labelStr := stripColorTags(label)
 		labelWidth := len(labelStr)
 		textWidth := len(text)
-		
+
 		// Position after the text
 		suggestionX := x + labelWidth + textWidth
 		suggestionY := y
-		
+
 		// Only draw if we are within bounds and there is space
 		if suggestionX < x+width {
 			currentX := suggestionX
 			style := tcell.StyleDefault.Foreground(styles.ColorDim).Background(styles.ColorBg)
-			
+
 			for _, r := range a.suggestionText {
 				if currentX >= x+width {
 					break
@@ -92,13 +92,13 @@ func NewCommandComponent(app common.AppController) *CommandComponent {
 		SetLabelColor(styles.ColorWhite).
 		SetFieldTextColor(styles.ColorFg).
 		SetLabel(fmt.Sprintf("[%s::b]VIEW> [-:%s:-]", styles.TagAccentLight, styles.TagBg))
-	
+
 	c.SetBorder(true).
 		SetBorderColor(styles.ColorAccentLight).
 		SetBackgroundColor(styles.ColorBg)
-	
+
 	c.SetApplication(app.GetTviewApp())
-	
+
 	comp := &CommandComponent{View: c, App: app}
 	comp.setupHandlers()
 	return comp
@@ -114,6 +114,9 @@ var availableCommands = []string{
 	"services",
 	"nodes",
 	"compose",
+	"context",
+	"contexts",
+	"ctx",
 	"help",
 	"aliases",
 	"q",
@@ -125,6 +128,7 @@ var availableCommands = []string{
 	"no",
 	"p",
 	"a",
+	"ctx",
 }
 
 // findBestSuggestion finds the best matching command for autocompletion
@@ -132,10 +136,10 @@ func findBestSuggestion(input string) string {
 	if input == "" {
 		return ""
 	}
-	
+
 	input = strings.ToLower(input)
 	bestMatch := ""
-	
+
 	for _, cmd := range availableCommands {
 		if strings.HasPrefix(cmd, input) && len(cmd) > len(input) {
 			if bestMatch == "" || len(cmd) < len(bestMatch) {
@@ -143,19 +147,19 @@ func findBestSuggestion(input string) string {
 			}
 		}
 	}
-	
+
 	// Robust check
 	if bestMatch != "" && len(input) < len(bestMatch) {
 		return bestMatch[len(input):] // Return only the suffix
 	}
-	
+
 	return ""
 }
 
 func (c *CommandComponent) updateSuggestion() {
 	text := c.View.GetText()
 	c.currentText = text
-	
+
 	// Only show suggestion in CMD mode (starts with :)
 	if strings.HasPrefix(text, ":") {
 		cmd := strings.TrimPrefix(text, ":")
@@ -183,25 +187,25 @@ func (c *CommandComponent) setupHandlers() {
 		if event.Key() == tcell.KeyEsc {
 			c.Reset()
 			c.App.SetActiveFilter("")
-			
+
 			c.App.RefreshCurrentView()
 			c.App.SetFlashText("")
-			
+
 			// Restore focus and hide cmdline
 			c.App.SetCmdLineVisible(false)
 			c.App.RestoreFocus()
 			return nil
 		}
-		
+
 		// Handle Tab to accept suggestion
 		if event.Key() == tcell.KeyTab {
 			c.acceptSuggestion()
 			return nil
 		}
-		
+
 		return event
 	})
-	
+
 	c.View.SetChangedFunc(func(text string) {
 		c.updateSuggestion()
 	})
@@ -215,7 +219,7 @@ func (c *CommandComponent) setupHandlers() {
 				if len(cmd) > 1 {
 					filter = strings.TrimPrefix(cmd, "/")
 				}
-				
+
 				// Apply Filter (even if empty, to clear it)
 				c.App.SetActiveFilter(filter)
 
@@ -223,9 +227,9 @@ func (c *CommandComponent) setupHandlers() {
 				// Command Mode
 				c.App.ExecuteCmd(cmd)
 			}
-			
+
 			c.Reset()
-			
+
 			// Restore focus and hide cmdline
 			c.App.SetCmdLineVisible(false)
 			c.App.RestoreFocus()
@@ -236,17 +240,17 @@ func (c *CommandComponent) setupHandlers() {
 
 func (c *CommandComponent) Activate(initial string) {
 	label := fmt.Sprintf("[%s:%s:b]CMD> [-:%s:-]", styles.TagAccentLight, styles.TagBg, styles.TagBg) // Defaults to Command
-	
+
 	if strings.HasPrefix(initial, "/") {
 		label = fmt.Sprintf("[%s:%s:b]FILTER> [-:%s:-]", styles.TagAccentLight, styles.TagBg, styles.TagBg)
-		
+
 		// Check if we are in Inspector -> SEARCH context
 		front, _ := c.App.GetPages().GetFrontPage()
 		if front == "inspect" {
 			label = fmt.Sprintf("[%s:%s:b]SEARCH> [-:%s:-]", styles.TagAccentLight, styles.TagBg, styles.TagBg)
 		}
 	}
-	
+
 	c.View.SetLabel(label)
 	c.View.SetText(initial)
 	c.App.GetTviewApp().SetFocus(c.View)

--- a/internal/ui/components/inspect/log_inspector.go
+++ b/internal/ui/components/inspect/log_inspector.go
@@ -26,18 +26,18 @@ type LogInspector struct {
 	ResourceID   string
 	Subject      string
 	ResourceType string
-	
+
 	// Settings
-	AutoScroll   bool
-	Timestamps   bool
-	Wrap         bool // Restored
-	filter       string
-	since        string
-	tail         string 
-	sinceLabel   string
-	
+	AutoScroll bool
+	Timestamps bool
+	Wrap       bool // Restored
+	filter     string
+	since      string
+	tail       string
+	sinceLabel string
+
 	// Control
-	cancelFunc   context.CancelFunc
+	cancelFunc context.CancelFunc
 }
 
 // Ensure implementation
@@ -102,7 +102,7 @@ func (i *LogInspector) GetStatus() string {
 	parts = append(parts, fmtStatus("[::b]Timestamps[::-]", i.Timestamps))
 	parts = append(parts, fmtStatus("[::b]Wrap[::-]", i.Wrap))
 	parts = append(parts, fmt.Sprintf("[%s::b]Since:[-::-][%s]%s[-]", styles.TagSCKey, styles.TagFg, i.sinceLabel))
-	
+
 	return strings.Join(parts, "     ")
 }
 
@@ -129,7 +129,7 @@ func (i *LogInspector) GetShortcuts() []string {
 	if paddingNeeded == maxPerCol {
 		paddingNeeded = 0
 	}
-	
+
 	for j := 0; j < paddingNeeded; j++ {
 		altShortcuts = append(altShortcuts, "")
 	}
@@ -145,7 +145,7 @@ func (i *LogInspector) GetShortcuts() []string {
 
 func (i *LogInspector) OnMount(app common.AppController) {
 	i.App = app
-	
+
 	i.HeaderView = tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignCenter).
@@ -159,7 +159,7 @@ func (i *LogInspector) OnMount(app common.AppController) {
 		SetWordWrap(i.Wrap). // Only affects word boundary, not line wrapping per se if SetWrap matches
 		SetWrap(i.Wrap).     // CRITICAL: SetWrap(false) allows horizontal scrolling
 		SetTextColor(styles.ColorIdle)
-	
+
 	i.TextView.SetChangedFunc(func() {
 		if i.AutoScroll {
 			i.TextView.ScrollToEnd()
@@ -178,7 +178,7 @@ func (i *LogInspector) OnMount(app common.AppController) {
 		SetBorderColor(styles.ColorIdle).
 		SetBackgroundColor(styles.ColorBlack).
 		SetBorderPadding(0, 0, 0, 0)
-		
+
 	i.startStreaming()
 }
 
@@ -199,12 +199,17 @@ func (i *LogInspector) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 		i.App.CloseInspector()
 		return nil
 	}
-	
+
+	if event.Rune() == ':' {
+		i.App.ActivateCmd(":")
+		return nil
+	}
+
 	if event.Rune() == '/' {
 		i.App.ActivateCmd("/")
 		return nil
 	}
-	
+
 	switch event.Rune() {
 	case 's':
 		i.AutoScroll = !i.AutoScroll
@@ -244,7 +249,7 @@ func (i *LogInspector) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	case '6':
 		i.setSince("1h")
 	}
-	
+
 	return event
 }
 
@@ -267,7 +272,7 @@ func (i *LogInspector) setSince(mode string) {
 		i.sinceLabel = "Tail"
 		i.AutoScroll = true
 	} else if mode == "head" {
-		i.since = "" 
+		i.since = ""
 		i.tail = "all"
 		i.sinceLabel = "Head"
 		i.AutoScroll = false
@@ -307,15 +312,15 @@ func (i *LogInspector) startStreaming() {
 
 	// Channels for buffering
 	logCh := make(chan string, 1000)
-	
+
 	go func() {
 		defer close(logCh)
-		
+
 		var reader io.ReadCloser
 		var err error
-		
+
 		docker := i.App.GetDocker()
-		
+
 		if i.ResourceType == "service" {
 			reader, err = docker.GetServiceLogs(i.ResourceID, i.since, i.tail, i.Timestamps)
 			if err == nil {
@@ -353,7 +358,7 @@ func (i *LogInspector) startStreaming() {
 		// Increase buffer size to handle large lines
 		buf := make([]byte, 0, 64*1024)
 		scanner.Buffer(buf, 5*1024*1024) // 5MB limit
-		
+
 		for scanner.Scan() {
 			select {
 			case <-ctx.Done():
@@ -363,7 +368,7 @@ func (i *LogInspector) startStreaming() {
 				logCh <- line
 			}
 		}
-		
+
 		if err := scanner.Err(); err != nil && err != context.Canceled && err != io.EOF {
 			logCh <- fmt.Sprintf("[%s]Stream Error: %v", styles.TagError, err)
 		}
@@ -409,14 +414,14 @@ func (i *LogInspector) startStreaming() {
 				if i.TextView == nil {
 					return
 				}
-				
+
 				if firstWrite {
 					i.TextView.Clear()
 				}
-				
+
 				// Calculate starting row
 				text := strings.Join(buffer, "\n") + "\n"
-				
+
 				// Apply color - ColorIdle is Blueish
 				fmt.Fprint(i.TextView, text)
 
@@ -428,7 +433,7 @@ func (i *LogInspector) startStreaming() {
 				} else if i.AutoScroll {
 					i.TextView.ScrollToEnd()
 				}
-				
+
 				buffer = buffer[:0] // Clear buffer but keep capacity
 			})
 		}
@@ -442,7 +447,7 @@ func (i *LogInspector) startStreaming() {
 				}
 
 				line = tview.TranslateANSI(tview.Escape(line))
-				
+
 				// Filter logic (supports negation with ^)
 				if i.filter != "" {
 					filterTerm := i.filter
@@ -470,35 +475,35 @@ func (i *LogInspector) startStreaming() {
 						}
 					}
 				}
-				
+
 				if i.ResourceType == "compose" {
 					// Compose Logs: "ContainerPrefix | LogPayload"
 					parts := strings.SplitN(line, "|", 2)
 					if len(parts) == 2 {
 						prefix := parts[0]
 						body := parts[1]
-						
+
 						// Determine unique color for this container prefix
 						key := strings.TrimSpace(prefix)
-						
+
 						col, exists := colorMap[key]
 						if !exists {
 							col = nextColor()
 							colorMap[key] = col
 						}
-						
+
 						// Handle timestamp which appears inside the body for compose logs
 						if i.Timestamps {
 							// Body usually starts with a space -> " 2023... msg"
 							trimmed := strings.TrimLeft(body, " ")
 							indent := body[:len(body)-len(trimmed)]
-							
+
 							tParts := strings.SplitN(trimmed, " ", 2)
 							if len(tParts) == 2 {
 								body = fmt.Sprintf("%s[%s]%s[-] %s", indent, styles.TagDim, tParts[0], tParts[1])
 							}
 						}
-						
+
 						// Color the prefix, reset, keep pipe, print body
 						line = fmt.Sprintf("[%s]%s[-]|%s", col, prefix, body)
 					} else {
@@ -512,7 +517,7 @@ func (i *LogInspector) startStreaming() {
 					if i.Timestamps {
 						parts := strings.SplitN(line, " ", 2)
 						if len(parts) == 2 {
-							// Check if first part looks like a timestamp? 
+							// Check if first part looks like a timestamp?
 							// Just blind replace for perf
 							line = fmt.Sprintf("[%s]%s[-] %s", styles.TagDim, parts[0], parts[1])
 						}
@@ -520,14 +525,14 @@ func (i *LogInspector) startStreaming() {
 
 					line = " [" + styles.TagIdle + "]" + line + " "
 				}
-				
+
 				buffer = append(buffer, line)
-				
+
 				// Optional: if buffer gets too big, flush immediately to avoid lag
 				if len(buffer) >= 1000 {
 					flush()
 				}
-				
+
 			case <-ticker.C:
 				flush()
 


### PR DESCRIPTION
Adds Docker context selection directly in d4s via :ctx, with support for saving a preferred defaultContext in config.yaml. This makes it easier to switch between local and remote docker targets from inside the TUI, while still respecting existing Docker overrides and precedence (--context, DOCKER_HOST, DOCKER_CONTEXT, then d4s.defaultContext).
