### PR TITLE
 feat(compose): Replace start and restart with up and add build action

### DIFF
--- a/internal/dao/compose/compose.go
+++ b/internal/dao/compose/compose.go
@@ -282,6 +282,18 @@ func (m *Manager) Logs(projectName string, since string, tail string, timestamps
 	return &cmdReadCloser{pipe: stdout, cmd: cmd}, nil
 }
 
+func (m *Manager) Down(projectName string) error {
+	var args []string
+	args = append(args, "compose", "-p", projectName, "down")
+
+	cmd := exec.Command("docker", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running docker compose down: %v, output: %s", err, string(output))
+	}
+	return nil
+}
+
 type cmdReadCloser struct {
 	pipe io.ReadCloser
 	cmd  *exec.Cmd
@@ -297,4 +309,3 @@ func (c *cmdReadCloser) Close() error {
 	}
 	return c.pipe.Close()
 }
-

--- a/internal/dao/compose/compose.go
+++ b/internal/dao/compose/compose.go
@@ -184,34 +184,6 @@ func (m *Manager) Stop(projectName string) error {
 	return nil
 }
 
-func (m *Manager) Restart(projectName string) error {
-	// Find all containers with this project name
-	args := filters.NewArgs()
-	args.Add("label", fmt.Sprintf("com.docker.compose.project=%s", projectName))
-	
-	containers, err := m.cli.ContainerList(m.ctx, container.ListOptions{Filters: args, All: true})
-	if err != nil {
-		return err
-	}
-
-	if len(containers) == 0 {
-		return fmt.Errorf("no containers found for project %s", projectName)
-	}
-
-	timeout := 10
-	var errs []string
-	for _, c := range containers {
-		if err := m.cli.ContainerRestart(m.ctx, c.ID, container.StopOptions{Timeout: &timeout}); err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v", c.Names[0], err))
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("errors restarting containers: %s", strings.Join(errs, "; "))
-	}
-	return nil
-}
-
 func (m *Manager) GetConfig(projectName string) (string, error) {
 	// Find one container to get config path
 	args := filters.NewArgs()
@@ -253,6 +225,34 @@ func (m *Manager) GetConfig(projectName string) (string, error) {
 	return sb.String(), nil
 }
 
+func (m *Manager) getConfigPaths(projectName string) ([]string, error) {
+	args := filters.NewArgs()
+	args.Add("label", fmt.Sprintf("com.docker.compose.project=%s", projectName))
+	
+	containers, err := m.cli.ContainerList(m.ctx, container.ListOptions{Filters: args, All: true, Limit: 1})
+	if err != nil {
+		return nil, err
+	}
+	
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("project '%s' not found or has no active containers to read configuration from", projectName)
+	}
+	
+	configFiles := containers[0].Labels["com.docker.compose.project.config_files"]
+	if configFiles == "" {
+		return nil, fmt.Errorf("no config files label found for project '%s'", projectName)
+	}
+	
+	var paths []string
+	for f := range strings.SplitSeq(configFiles, ",") {
+		path := strings.TrimSpace(f)
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
+}
+
 func (m *Manager) Logs(projectName string, since string, tail string, timestamps bool) (io.ReadCloser, error) {
 	args := []string{"compose", "-p", projectName, "logs", "-f"}
 	if tail != "" && tail != "all" {
@@ -290,6 +290,46 @@ func (m *Manager) Down(projectName string) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error running docker compose down: %v, output: %s", err, string(output))
+	}
+	return nil
+}
+
+func (m *Manager) Up(projectName string) error {
+	paths, err := m.getConfigPaths(projectName)
+	if err != nil {
+		return fmt.Errorf("failed to up project: %v", err)
+	}
+
+	args := []string{"compose", "-p", projectName}
+	for _, path := range paths {
+		args = append(args, "-f", path)
+	}
+	args = append(args, "up", "-d", "--force-recreate")
+
+	cmd := exec.Command("docker", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running docker compose up: %v\nOutput: %s", err, string(output))
+	}
+	return nil
+}
+
+func (m *Manager) Build(projectName string) error {
+	paths, err := m.getConfigPaths(projectName)
+	if err != nil {
+		return fmt.Errorf("failed to build project: %v", err)
+	}
+
+	args := []string{"compose", "-p", projectName}
+	for _, path := range paths {
+		args = append(args, "-f", path)
+	}
+	args = append(args, "up", "-d", "--build")
+
+	cmd := exec.Command("docker", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running docker compose up --build: %v\nOutput: %s", err, string(output))
 	}
 	return nil
 }

--- a/internal/dao/docker.go
+++ b/internal/dao/docker.go
@@ -551,8 +551,12 @@ func (d *DockerClient) StopComposeProject(projectName string) error {
 	return d.Compose.Stop(projectName)
 }
 
-func (d *DockerClient) RestartComposeProject(projectName string) error {
-	return d.Compose.Restart(projectName)
+func (d *DockerClient) UpComposeProject(projectName string) error {
+	return d.Compose.Up(projectName)
+}
+
+func (d *DockerClient) BuildComposeProject(projectName string) error {
+	return d.Compose.Build(projectName)
 }
 
 func (d *DockerClient) DownComposeProject(projectName string) error {

--- a/internal/dao/docker.go
+++ b/internal/dao/docker.go
@@ -555,6 +555,10 @@ func (d *DockerClient) RestartComposeProject(projectName string) error {
 	return d.Compose.Restart(projectName)
 }
 
+func (d *DockerClient) DownComposeProject(projectName string) error {
+	return d.Compose.Down(projectName)
+}
+
 func (d *DockerClient) GetComposeConfig(projectName string) (string, error) {
 	return d.Compose.GetConfig(projectName)
 }

--- a/internal/ui/views/compose/compose.go
+++ b/internal/ui/views/compose/compose.go
@@ -83,6 +83,7 @@ func GetShortcuts() []string {
 		common.FormatSCHeader("d", "Describe"),
 		common.FormatSCHeader("e", "Edit"),
 		common.FormatSCHeader("r", "(Re)Start"),
+		common.FormatSCHeader("b", "Build"),
 		common.FormatSCHeader("ctrl-d", "Delete"),
 		common.FormatSCHeader("ctrl-k", "Stop"),
 	}
@@ -109,7 +110,10 @@ func InputHandler(v *view.ResourceView, event *tcell.EventKey) *tcell.EventKey {
 		EditAction(app, v)
 		return nil
 	case 'r':
-		RestartAction(app, v)
+		UpAction(app, v)
+		return nil
+	case 'b':
+		BuildAction(app, v)
 		return nil
 	}
 	
@@ -155,12 +159,6 @@ func NavigateToContainers(app common.AppController, v *view.ResourceView) {
 		// Switch to Containers
 		app.SwitchTo(styles.TitleContainers)
 	}
-}
-
-func RestartAction(app common.AppController, v *view.ResourceView) {
-	app.PerformAction(func(id string) error {
-		return app.GetDocker().RestartComposeProject(id)
-	}, "restarting", styles.ColorStatusOrange)
 }
 
 func StopAction(app common.AppController, v *view.ResourceView) {
@@ -231,6 +229,18 @@ func EditAction(app common.AppController, v *view.ResourceView) {
 	}
 }
 
+func UpAction(app common.AppController, v *view.ResourceView) {
+	app.PerformAction(func(id string) error {
+		return app.GetDocker().UpComposeProject(id)
+	}, "restarting", styles.ColorStatusYellow)
+}
+
+func BuildAction(app common.AppController, v *view.ResourceView) {
+	app.PerformAction(func(id string) error {
+		return app.GetDocker().BuildComposeProject(id)
+	}, "building", styles.ColorStatusYellow)
+}
+
 func DeleteAction(app common.AppController, v *view.ResourceView) {
 	ids, err := v.GetSelectedIDs()
 	if err != nil || len(ids) == 0 {
@@ -271,10 +281,6 @@ func DeleteAction(app common.AppController, v *view.ResourceView) {
 		// Perform the action with the consistent styling
 		app.PerformAction(batchDeleteAction, "deleting", styles.ColorStatusRed)
 	})
-}
-
-func Restart(app common.AppController, id string) error {
-	return app.GetDocker().RestartComposeProject(id)
 }
 
 func Stop(app common.AppController, id string) error {

--- a/internal/ui/views/compose/compose.go
+++ b/internal/ui/views/compose/compose.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jr-k/d4s/internal/ui/common"
 	"github.com/jr-k/d4s/internal/ui/components/inspect"
 	"github.com/jr-k/d4s/internal/ui/components/view"
+	"github.com/jr-k/d4s/internal/ui/dialogs"
 	"github.com/jr-k/d4s/internal/ui/styles"
 )
 
@@ -91,6 +92,10 @@ func InputHandler(v *view.ResourceView, event *tcell.EventKey) *tcell.EventKey {
 	app := v.App
 	if event.Key() == tcell.KeyCtrlK {
 		StopAction(app, v)
+		return nil
+	}
+	if event.Key() == tcell.KeyCtrlD {
+		DeleteAction(app, v)
 		return nil
 	}
 	switch event.Rune() {
@@ -226,10 +231,56 @@ func EditAction(app common.AppController, v *view.ResourceView) {
 	}
 }
 
+func DeleteAction(app common.AppController, v *view.ResourceView) {
+	ids, err := v.GetSelectedIDs()
+	if err != nil || len(ids) == 0 {
+		return
+	}
+
+	label := ids[0]
+	if len(ids) > 1 {
+		label = fmt.Sprintf("%d items", len(ids))
+	}
+
+	// Stop background refresh to prevent UI flickering during confirmation/deletion
+	app.StopAutoRefresh()
+	app.SetPaused(true)
+
+	dialogs.ShowConfirmation(app, "DELETE", label, func(force bool) {
+		// Ensure we always resume UI refresh cycles when the action completes or cancels
+		defer func() {
+			app.SetPaused(false)
+			app.StartAutoRefresh()
+			
+			// Force UI sync to clean up any leftover artifacts from the dialog
+			if app.GetScreen() != nil {
+				app.GetScreen().Sync()
+			}
+		}()
+
+		// Define the multi-item deletion task
+		batchDeleteAction := func(_ string) error {
+			for _, id := range ids {
+				if err := Remove(id, force, app); err != nil {
+					return err // Halts and displays error if one fails
+				}
+			}
+			return nil
+		}
+
+		// Perform the action with the consistent styling
+		app.PerformAction(batchDeleteAction, "deleting", styles.ColorStatusRed)
+	})
+}
+
 func Restart(app common.AppController, id string) error {
 	return app.GetDocker().RestartComposeProject(id)
 }
 
 func Stop(app common.AppController, id string) error {
 	return app.GetDocker().StopComposeProject(id)
+}
+
+func Remove(id string, force bool, app common.AppController) error {
+	return app.GetDocker().DownComposeProject(id)
 }


### PR DESCRIPTION
I think the current implementation of (Re)Start is misleading. Since I expect a restart to reapply the changes made to the docker-compose file, it would be better and safer if the restart was handled via `docker compose up`.

I also added a separate build action to run the up command with `--build`.

depends on https://github.com/jr-k/d4s/pull/16